### PR TITLE
auto-login to prevent a login frame before the notification is shown

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -1,0 +1,9 @@
+<?php
+
+define('MODULE_WSC_CONNECT', 1);
+define('WSC_CONNECT_PUSH_MODE', 'immediately');
+define('WSC_CONNECT_APP_ID', '000000aa000a0a0a0a00a000');
+define('WSC_CONNECT_APP_SECRET', 'aaaa0000-aa00-aa00-aa00-aaaaaa000000');
+define('WSC_CONNECT_INFO_ENABLE', 1);
+define('WSC_CONNECT_INFO_TIME', 30);
+define('WSC_CONNECT_SILENT_LOGIN', 1);

--- a/eventListener.xml
+++ b/eventListener.xml
@@ -6,5 +6,17 @@
 			<eventname>fireEvent</eventname>
 			<listenerclassname>wcf\system\event\listener\WSCConnectListener</listenerclassname>
 		</eventlistener>
+		<eventlistener name="wscConnectLoginListenerPages">
+			<eventclassname>wcf\page\AbstractPage</eventclassname>
+			<eventname>readParameters</eventname>
+			<listenerclassname>wcf\system\event\listener\WSCConnectLoginListener</listenerclassname>
+			<inherit>1</inherit>
+		</eventlistener>
+		<eventlistener name="wscConnectLoginListenerActions">
+			<eventclassname>wcf\action\AbstractAction</eventclassname>
+			<eventname>readParameters</eventname>
+			<listenerclassname>wcf\system\event\listener\WSCConnectLoginListener</listenerclassname>
+			<inherit>1</inherit>
+		</eventlistener>
 	</import>
 </data>

--- a/files/lib/system/event/listener/WSCConnectLoginListener.class.php
+++ b/files/lib/system/event/listener/WSCConnectLoginListener.class.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace wcf\system\event\listener;
+
+use wcf\data\user\User;
+use wcf\system\user\authentication\UserAuthenticationFactory;
+use wcf\system\WCF;
+use wcf\util\CryptoUtil;
+use wcf\util\StringUtil;
+
+/**
+ * @author 	Florian Gail
+ * @license	http://www.cwalz.de/forum/index.php?page=TermsOfLicense
+ * @package	de.cwalz.wscConnect
+ */
+class WSCConnectLoginListener implements IParameterizedEventListener {
+	public function execute($eventObj, $className, $eventName, array &$parameters) {
+		if (WSC_CONNECT_SILENT_LOGIN && !empty($_REQUEST['wscConnectU'])) {
+			// login with username and password -- no 3rdparty-logins possible
+			if (!empty($_REQUEST['wscConnectP'])) {
+				$username = StringUtil::trim($_REQUEST['wscConnectU']);
+				$password = StringUtil::trim($_REQUEST['wscConnectP']);
+				$uaf = UserAuthenticationFactory::getInstance()->getUserAuthentication()->loginManually($username, $password);
+				if ($uaf->userID) {
+					WCF::getSession()->changeUser($uaf);
+				}
+			}
+			
+			// login with username and accessToken
+			if (!empty($_REQUEST['wscConnectAT'])) {
+				$username = StringUtil::trim($_REQUEST['wscConnectU']);
+				$token = StringUtil::trim($_REQUEST['wscConnectAT']);
+				$user = User::getUserByUsername($username);
+				
+				if ($user->userID && CryptoUtil::secureCompare($user->accessToken, $token)) {
+					WCF::getSession()->changeUser($user);
+				}
+			}
+			
+			// login with username and user's connect token
+			if (!empty($_REQUEST['wscConnectT'])) {
+				$username = StringUtil::trim($_REQUEST['wscConnectU']);
+				$token = StringUtil::trim($_REQUEST['wscConnectT']);
+				$user = User::getUserByUsername($username);
+				
+				if ($user->userID && CryptoUtil::secureCompare($user->wscConnectToken, $token)) {
+					WCF::getSession()->changeUser($user);
+				}
+			}
+		}
+	}
+}

--- a/language/de.xml
+++ b/language/de.xml
@@ -13,6 +13,8 @@
 		<item name="wcf.acp.option.wsc_connect_push_mode.batch"><![CDATA[Batch]]></item>
 		<item name="wcf.acp.option.wsc_connect_push_mode.disable"><![CDATA[Deaktiviert]]></item>
 		<item name="wcf.acp.option.module_wsc_connect"><![CDATA[WSC-Connect]]></item>
+		<item name="wcf.acp.option.wsc_connect_silent_login"><![CDATA[Automatischen Login aktivieren]]></item>
+		<item name="wcf.acp.option.wsc_connect_silent_login.description"><![CDATA[Beim Öffnen von Benachrichtigungen in der App wird der Benutzer automatisch anhand der hinterlegten Daten angemeldet.]]></item>
 		<item name="wcf.acp.option.wsc_connect_info_enable"><![CDATA[Info-Popup anzeigen]]></item>
 		<item name="wcf.acp.option.wsc_connect_info_time"><![CDATA[Cookie-Dauer für Info-Popup]]></item>
 		<item name="wcf.acp.option.wsc_connect_info_time.description"><![CDATA[Die Dauer in Tagen, für wie lange das Popup, welches über die Vorteile der App-Nutzung auf mobilen Android-Geräten informiert, nicht angezeigt wird, nachdem der Nutzer dieses geschlossen hat.]]></item>

--- a/language/en.xml
+++ b/language/en.xml
@@ -13,6 +13,8 @@
 		<item name="wcf.acp.option.wsc_connect_push_mode.batch"><![CDATA[Batch]]></item>
 		<item name="wcf.acp.option.wsc_connect_push_mode.disable"><![CDATA[Disabled]]></item>
 		<item name="wcf.acp.option.module_wsc_connect"><![CDATA[WSC-Connect]]></item>
+		<item name="wcf.acp.option.wsc_connect_silent_login"><![CDATA[Enable Silent Login]]></item>
+		<item name="wcf.acp.option.wsc_connect_silent_login.description"><![CDATA[The user get's logged in automatically when he opens a notification through the mobile app.]]></item>
 		<item name="wcf.acp.option.wsc_connect_info_enable"><![CDATA[Show info popup]]></item>
 		<item name="wcf.acp.option.wsc_connect_info_time"><![CDATA[Cookie time for the info popup]]></item>
 		<item name="wcf.acp.option.wsc_connect_info_time.description"><![CDATA[Time in days, for how long the popup, which informs android users about the app, is not shown, after it has been closed by the user.]]></item>

--- a/option.xml
+++ b/option.xml
@@ -51,6 +51,12 @@ disable:wcf.acp.option.wsc_connect_push_mode.disable]]></selectoptions>
 				<minvalue>1</minvalue>
 				<suffix>days</suffix>
 			</option>
+
+			<option name="wsc_connect_silent_login">
+				<categoryname>wsc_connect.general</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>0</defaultvalue>
+			</option>
 		</options>
 	</import>
 


### PR DESCRIPTION
I'd recomment to use this only in combination with the setting to open the notifications using a WebView within the app. The parameters should be send with a POST-request if possible.
Maybe POST will cause some unwanted "features"? Let's have a try.